### PR TITLE
reduce page load time impact for content-heavy sites by using ajax & cache

### DIFF
--- a/assets/js/jqueryfunctions.js
+++ b/assets/js/jqueryfunctions.js
@@ -1,3 +1,53 @@
+var WPJM_PARENT_ID = '#wp-admin-bar-wp-jump-menu';
+var CACHE_KEY = 'wpjm_entries';
+
+function wpjm_get_opts() {
+    return jQuery(WPJM_PARENT_ID).data('opts');
+}
+
+function wpjm_render(html) {
+    var opts = wpjm_get_opts();
+    var $parent = jQuery(WPJM_PARENT_ID);
+    $parent.append(html);
+    var $el = jQuery('#wp-pdd').on('change', function () {
+        if (this.value === '__reload__') {
+            wpjm_load();
+        } else {
+            window.location = this.value;
+        }
+    });
+    if (window.localStorage) {
+        var $clearCacheOpt = jQuery('<option value="__reload__">' + opts.reloadText + '</option>');
+        $el.find('option:last').parent().append($clearCacheOpt);
+    }
+    if (opts.useChosen) {
+        $el.customChosen({position: opts.position, search_contains: true});
+    }
+}
+
+function wpjm_load() {
+    // remove old stuff if it's there
+    jQuery(WPJM_PARENT_ID).children('*:not(script):not(.ab-item)').remove();
+    // load new
+    jQuery.get(wpjm_get_opts().baseUrl + '?action=wpjm_menu', function (html) {
+        if (window.localStorage) {
+            localStorage.setItem(CACHE_KEY, html);
+        }
+        wpjm_render(html);
+    });
+}
+
+wpjm_init_html = function (opts) {
+    var $parent = jQuery(WPJM_PARENT_ID);
+    $parent.data('opts', opts);
+
+    var cached = window.localStorage && window.localStorage.getItem(CACHE_KEY);
+    if (cached) {
+        wpjm_render(cached);
+    }
+    $parent.find('.ab-item').click(wpjm_load);
+};
+
 jQuery(document).ready(function() {
 
 		if (jQuery('#wpjm-options-form').length > 0) {


### PR DESCRIPTION
loading actual menu content via ajax to keep initial page load time impact low; caching that content in localStorage for great performance on content-heavy sites; cache can be cleared with 1 click from menu (or by clicking on admin menu title)

also reorganized js slightly, moved as much js as possible to external js file rather than letting it stay within php.